### PR TITLE
r-gdalraster: update the gdalraster dev install to firelab r-universe

### DIFF
--- a/scripts/install-r-gdalraster.sh
+++ b/scripts/install-r-gdalraster.sh
@@ -21,7 +21,7 @@ Rscript -e 'install.packages(c("Rcpp", "RcppInt64", "nanoarrow", "bit64", "wk", 
 # since it is only for display.
 Rscript -e 'install.packages(c("gt", "knitr", "rmarkdown", "scales", "testthat"))'
 
-Rscript -e 'install.packages("gdalraster", repos = c("https://usdaforestservice.r-universe.dev", "https://cran.r-project.org"), INSTALL_opts = "--install-tests")'
+Rscript -e 'install.packages("gdalraster", repos = c("https://firelab.r-universe.dev", "https://cran.r-project.org"), INSTALL_opts = "--install-tests")'
 
 ## get the artefacts
 mkdir dev-pkgs


### PR DESCRIPTION
It currently falls back to a CRAN install of the gdalraster release version, which fails due to the `CSLConstList` change in GDAL 3.13 dev.